### PR TITLE
Fix test namespace declarations

### DIFF
--- a/src/ContosoUniversity.Test/CoursesTest.cs
+++ b/src/ContosoUniversity.Test/CoursesTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ContosoUniversity.XUnitTest
+namespace ContosoUniversity.Test
 {
     [TestClass]
     public class CoursesTest

--- a/src/ContosoUniversity.Test/DepartamentsTest.cs
+++ b/src/ContosoUniversity.Test/DepartamentsTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ContosoUniversity.XUnitTest
+namespace ContosoUniversity.Test
 {
     [TestClass]
     public class DepartamentsTest

--- a/src/ContosoUniversity.Test/InstructorsTest.cs
+++ b/src/ContosoUniversity.Test/InstructorsTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace ContosoUniversity.XUnitTest
+namespace ContosoUniversity.Test
 {
     [TestClass]
     public class InstructorsTest


### PR DESCRIPTION
## Summary
- set test namespaces to `ContosoUniversity.Test`

## Testing
- `dotnet test src/ContosoUniversity.Test/ContosoUniversity.Test.csproj --verbosity normal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c07ec3c48832b90dd013a0414a3fc