### PR TITLE
Add build-only workflow

### DIFF
--- a/.github/workflows/ContosoUniversityBuildOnly.yml
+++ b/.github/workflows/ContosoUniversityBuildOnly.yml
@@ -1,0 +1,61 @@
+name: ContosoUniversityBuildOnly
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'infra/**'
+      - '**/ContosoUniversity - Infra.yml'
+      - '**/README.md'
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'infra/**'
+  workflow_dispatch:
+
+env:
+  CONFIGURATION: release
+  AZ_APP_NAME: ${{ secrets.AZURE_ENVIRONMENT_NAME }}-app
+  AZ_API_NAME: ${{ secrets.AZURE_ENVIRONMENT_NAME }}-api
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '6.0.x'
+
+    - name: Restore
+      run: dotnet restore src/ContosoUniversity.sln
+
+    - name: Build
+      run: dotnet build src/ContosoUniversity.sln --configuration ${{ env.CONFIGURATION }} --no-restore
+
+    - name: Test
+      run: dotnet test src/ContosoUniversity.Test/ContosoUniversity.Test.csproj --verbosity normal --logger trx --results-directory TestResults
+
+    - name: Publish APP
+      run: dotnet publish --configuration ${{ env.CONFIGURATION }} --output PublishApp src/ContosoUniversity.WebApplication/ContosoUniversity.WebApplication.csproj
+
+    - name: Publish API
+      run: dotnet publish --configuration ${{ env.CONFIGURATION }} --output PublishApi src/ContosoUniversity.API/ContosoUniversity.API.csproj
+
+    - name: Upload APP results
+      uses: actions/upload-artifact@v4
+      with:
+        name: app
+        path: PublishApp
+
+    - name: Upload API results
+      uses: actions/upload-artifact@v4
+      with:
+        name: api
+        path: PublishApi


### PR DESCRIPTION
## Summary
- add build-only workflow derived from `ContosoUniversity.yml`
- omit the release job

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c0c1106f8832bb38dc2d5692103d7