### PR TITLE
fix StudentCourse seed validation

### DIFF
--- a/src/ContosoUniversity.API/Data/DbInitializer.cs
+++ b/src/ContosoUniversity.API/Data/DbInitializer.cs
@@ -74,8 +74,13 @@ namespace ContosoUniversity.API.Data
                     new StudentCourse
                     {
                         StudentID = i,
-                        CourseID = random.Next(courses.Length)
+                        CourseID = courses[random.Next(courses.Length)].ID
                     });
+            }
+
+            if (!studentCourse.All(sc => courses.Any(c => c.ID == sc.CourseID)))
+            {
+                throw new InvalidOperationException("StudentCourse references non-existing Course");
             }
 
             await context.StudentCourse.AddRangeAsync(studentCourse);


### PR DESCRIPTION
## Summary
- enforce StudentCourse seeding references valid Course IDs by throwing `InvalidOperationException`
- remove unused `System.Diagnostics` import

## Testing
- ❌ `dotnet restore src/ContosoUniversity.sln`
- ❌ `dotnet format --verify-no-changes`
- ❌ `dotnet build src/ContosoUniversity.sln`
- ❌ `dotnet test src/ContosoUniversity.sln --no-restore --verbosity minimal --logger "console;verbosity=normal"`
- ❌ `dotnet build src/ContosoUniversity.sln --configuration Release`
- ❌ `dotnet publish src/ContosoUniversity.sln --configuration Release --output ./artifacts`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_683c169fe54c832bbf9e5d0aaf45169b